### PR TITLE
Add support for SQLite3 full-text-search and other virtual tables

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add support for SQLite3 full-text-search and other virtual tables.
+
+    Previosuly, adding sqlite3 virtual tables messed up `schema.rb`.
+
+    Now, virtual tables can safely be added using `create_virtual_table`.
+
+    *Zacharias Knudsen*
+
+
 *   Fix duplicate callback execution when child autosaves parent with `has_one` and `belongs_to`.
 
     Before, persisting a new child record with a new associated parent record would run `before_validation`,

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -595,6 +595,14 @@ module ActiveRecord
       def rename_enum_value(*) # :nodoc:
       end
 
+      # This is meant to be implemented by the adapters that support virtual tables
+      def create_virtual_table(*) # :nodoc:
+      end
+
+      # This is meant to be implemented by the adapters that support virtual tables
+      def drop_virtual_table(*) # :nodoc:
+      end
+
       def advisory_locks_enabled? # :nodoc:
         supports_advisory_locks? && @advisory_locks_enabled
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
@@ -5,6 +5,19 @@ module ActiveRecord
     module SQLite3
       class SchemaDumper < ConnectionAdapters::SchemaDumper # :nodoc:
         private
+          def virtual_tables(stream)
+            virtual_tables = @connection.virtual_tables
+            if virtual_tables.any?
+              stream.puts "  # Virtual tables defined in this database."
+              stream.puts "  # Note that virtual tables may not work with other database engines. Be careful if changing database."
+              virtual_tables.sort.each do |table_name, options|
+                module_name, arguments = options
+                stream.puts "  create_virtual_table #{table_name.inspect}, #{module_name.inspect}, #{arguments.split(", ").inspect}"
+              end
+              stream.puts
+            end
+          end
+
           def default_primary_key?(column)
             schema_type(column) == :integer
           end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -82,6 +82,10 @@ module ActiveRecord
           alter_table(from_table, foreign_keys)
         end
 
+        def virtual_table_exists?(table_name)
+          query_values(data_source_sql(table_name, type: "VIRTUAL TABLE"), "SCHEMA").any? if table_name.present?
+        end
+
         def check_constraints(table_name)
           table_sql = query_value(<<-SQL, "SCHEMA")
             SELECT sql
@@ -174,9 +178,10 @@ module ActiveRecord
 
           def data_source_sql(name = nil, type: nil)
             scope = quoted_scope(name, type: type)
-            scope[:type] ||= "'table','view'"
+            scope[:type] ||= "'table','view','virtual'"
 
-            sql = +"SELECT name FROM sqlite_master WHERE name <> 'sqlite_sequence'"
+            sql = +"SELECT name FROM pragma_table_list WHERE schema <> 'temp'"
+            sql << " AND name NOT IN ('sqlite_sequence', 'sqlite_schema')"
             sql << " AND name = #{scope[:name]}" if scope[:name]
             sql << " AND type IN (#{scope[:type]})"
             sql
@@ -189,6 +194,8 @@ module ActiveRecord
                 "'table'"
               when "VIEW"
                 "'view'"
+              when "VIRTUAL TABLE"
+                "'virtual'"
               end
             scope = {}
             scope[:name] = quote(name) if name

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -278,6 +278,38 @@ module ActiveRecord
         exec_query "DROP INDEX #{quote_column_name(index_name)}"
       end
 
+      VIRTUAL_TABLE_REGEX = /USING\s+(\w+)\s*\((.+)\)/i
+
+      # Returns a list of defined virtual tables
+      def virtual_tables
+        query = <<~SQL
+          SELECT name, sql FROM sqlite_master WHERE sql LIKE 'CREATE VIRTUAL %';
+        SQL
+
+        exec_query(query, "SCHEMA").cast_values.each_with_object({}) do |row, memo|
+          table_name, sql = row[0], row[1]
+          _, module_name, arguments = sql.match(VIRTUAL_TABLE_REGEX).to_a
+          memo[table_name] = [module_name, arguments]
+        end.to_a
+      end
+
+      # Creates a virtual table
+      #
+      # Example:
+      #   create_virtual_table :emails, :fts5, 'sender', 'title',' body'
+      def create_virtual_table(table_name, module_name, values)
+        exec_query "CREATE VIRTUAL TABLE IF NOT EXISTS #{table_name} USING #{module_name} (#{values.join(", ")})"
+      end
+
+      # Drops a virtual table
+      #
+      # Although this command ignores +module_name+ and +values+,
+      # it can be helpful to provide these in a migration's +change+ method so it can be reverted.
+      # In that case, +module_name+, +values+ and +options+ will be used by #create_virtual_table.
+      def drop_virtual_table(table_name, module_name, values, **options)
+        drop_table(table_name)
+      end
+
       # Renames a table.
       #
       # Example:

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -22,10 +22,12 @@ module ActiveRecord
     # * change_table_comment (must supply a +:from+ and +:to+ option)
     # * create_enum
     # * create_join_table
+    # * create_virtual_table
     # * create_table
     # * disable_extension
     # * drop_enum (must supply a list of values)
     # * drop_join_table
+    # * drop_virtual_table (must supply options)
     # * drop_table (must supply a block)
     # * enable_extension
     # * remove_column (must supply a type)
@@ -55,6 +57,7 @@ module ActiveRecord
         :add_exclusion_constraint, :remove_exclusion_constraint,
         :add_unique_constraint, :remove_unique_constraint,
         :create_enum, :drop_enum, :rename_enum, :add_enum_value, :rename_enum_value,
+        :create_virtual_table, :drop_virtual_table
       ]
       include JoinTable
 
@@ -163,7 +166,8 @@ module ActiveRecord
               add_exclusion_constraint: :remove_exclusion_constraint,
               add_unique_constraint: :remove_unique_constraint,
               enable_extension:  :disable_extension,
-              create_enum:       :drop_enum
+              create_enum:       :drop_enum,
+              create_virtual_table: :drop_virtual_table
             }.each do |cmd, inv|
               [[inv, cmd], [cmd, inv]].uniq.each do |method, inverse|
                 class_eval <<-EOV, __FILE__, __LINE__ + 1
@@ -370,6 +374,12 @@ module ActiveRecord
           end
 
           [:rename_enum_value, [type_name, from: options[:to], to: options[:from]]]
+        end
+
+        def invert_drop_virtual_table(args)
+          _enum, values = args.dup.tap(&:extract_options!)
+          raise ActiveRecord::IrreversibleMigration, "drop_virtual_table is only reversible if given options." unless values
+          super
         end
 
         def respond_to_missing?(method, _)

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -63,6 +63,7 @@ module ActiveRecord
       extensions(stream)
       types(stream)
       tables(stream)
+      virtual_tables(stream)
       trailer(stream)
       stream
     end
@@ -124,6 +125,10 @@ module ActiveRecord
 
       # schemas are only supported by PostgreSQL
       def schemas(stream)
+      end
+
+      # virtual tables are only supported by SQLite
+      def virtual_tables(stream)
       end
 
       def tables(stream)

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -596,7 +596,7 @@ module ActiveRecord
 
       def test_tables_logs_name
         sql = <<~SQL
-          SELECT name FROM sqlite_master WHERE name <> 'sqlite_sequence' AND type IN ('table')
+          SELECT name FROM pragma_table_list WHERE schema <> 'temp' AND name NOT IN ('sqlite_sequence', 'sqlite_schema') AND type IN ('table')
         SQL
         @conn.connect!
         assert_logged [[sql.squish, "SCHEMA", []]] do
@@ -607,7 +607,7 @@ module ActiveRecord
       def test_table_exists_logs_name
         with_example_table do
           sql = <<~SQL
-            SELECT name FROM sqlite_master WHERE name <> 'sqlite_sequence' AND name = 'ex' AND type IN ('table')
+            SELECT name FROM pragma_table_list WHERE schema <> 'temp' AND name NOT IN ('sqlite_sequence', 'sqlite_schema') AND name = 'ex' AND type IN ('table')
           SQL
           assert_logged [[sql.squish, "SCHEMA", []]] do
             assert @conn.table_exists?("ex")

--- a/activerecord/test/cases/adapters/sqlite3/virtual_table_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/virtual_table_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "support/connection_helper"
+require "support/schema_dumping_helper"
+
+class SQLite3VirtualTableTest < ActiveRecord::SQLite3TestCase
+  include ConnectionHelper
+  include SchemaDumpingHelper
+
+  def setup
+    @connection = ActiveRecord::Base.lease_connection
+    @connection.create_virtual_table :searchables, :fts5, ["content", "meta UNINDEXED", "tokenize='porter ascii'"]
+  end
+
+  def teardown
+    @connection.drop_table :searchables, if_exists: true
+    reset_connection
+  end
+
+  def test_schema_dump
+    output = dump_all_table_schema
+
+    assert_includes output, 'create_virtual_table "searchables", "fts5", ["content", "meta UNINDEXED", "tokenize=\'porter ascii\'"]'
+  end
+
+  def test_schema_load
+    original, $stdout = $stdout, StringIO.new
+
+    ActiveRecord::Schema.define do
+      create_virtual_table :emails, :fts5, ["content", "meta UNINDEXED"]
+    end
+
+    assert @connection.virtual_table_exists?(:emails)
+  ensure
+    $stdout = original
+  end
+end

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -554,6 +554,22 @@ module ActiveRecord
           @recorder.inverse_of :rename_enum_value, [:dog_breed, from: :beagle]
         end
       end
+
+      def test_invert_create_virtual_table
+        drop = @recorder.inverse_of :create_virtual_table, [:searchables, :fts5, ["content", "meta UNINDEXED", "tokenize='porter ascii'"]]
+        assert_equal [:drop_virtual_table, [:searchables, :fts5, ["content", "meta UNINDEXED", "tokenize='porter ascii'"]], nil], drop
+      end
+
+      def test_invert_drop_virtual_table
+        create = @recorder.inverse_of :drop_virtual_table, [:searchables, :fts5, ["title", "content"]]
+        assert_equal [:create_virtual_table, [:searchables, :fts5, ["title", "content"]], nil], create
+      end
+
+      def test_invert_drop_virtual_table_without_options
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.inverse_of :drop_virtual_table, [:searchables]
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

As [discussed on rubyonrails-core](https://discuss.rubyonrails.org/t/proposal-sqlite3-full-text-search-and-other-virtual-tables-do-not-dump-shadow-virtual-tables/86159).

SQLite is a great default database, and even provides a [full-text-search module, `fts5`](https://www.sqlite.org/fts5.html). However, `fts5` is a [virtual table module](https://www.sqlite.org/vtab.html) which messes up `schema.rb`. For example, if you create virtual table `searchables` in a migration:

```ruby
class CreateSearchablesTable < ActiveRecord::Migration[8.0]
  def up
    execute 'CREATE VIRTUAL TABLE searchables USING fts5(content)'
  end
end
```
and run `rails db:migrate`, then 6 tables are created, 1 `virtual` and 5 "`shadow`" tables. This is what the result of `SELECT * FROM pragma_table_list ORDER BY name` (relevant part) looks like:
| schema | name | type | ncol | wr | strict |
| - | - | - | - | - | - |
| main | searchables | virtual | 3 | 0 | 0 |
| main | searchables_config | shadow | 2 | 1 | 0 |
| main | searchables_content | shadow | 2 | 0 | 0 |
| main | searchables_data | shadow | 2 | 0 | 0 |
| main | searchables_docsize | shadow | 2 | 0 | 0 |
| main | searchables_idx | shadow | 3 | 1 | 0 |

While these tables look like regular tables, they should not be dumped in the same way. In `schema.rb` there are error messages for some of them (notably the virtual table) while a few shadow tables are dumped like regular tables:

```ruby
# Could not dump table "searchables" because of following StandardError
#   Unknown type '' for column 'content'

# Could not dump table "searchables_config" because of following StandardError
#   Unknown type '' for column 'k'

# Could not dump table "searchables_content" because of following StandardError
#   Unknown type '' for column 'c0'

  create_table "searchables_data", force: :cascade do |t|
    t.binary "block"
  end

  create_table "searchables_docsize", force: :cascade do |t|
    t.binary "sz"
  end

# Could not dump table "searchables_idx" because of following StandardError
#   Unknown type '' for column 'segid'
```
This will put the app into a bad state if you run `rails db:reset`, with some shadow tables as regular tables and the virtual table missing entirely:

| schema | name | type | ncol | wr | strict |
| - | - | - | - | - | - |
| main | searchables_data | table | 2 | 0 | 0
| main | searchables_docsize | table | 2 | 0 | 0

The proper way to dump a virtual table to `schema.rb` would be to ignore the "shadow" tables and only create the virtual table (which in turn will create the shadow tables).

### Detail

This PR tries to provide general SQLite3 virtual table support using `create_virtual_table` and `drop_virtual_table`. While `drop_virtual_table` is basically `drop_table` (since dropping a virtual table also drops connected shadow tables), it allows the `CommandRecorder` to reverse `drop_virtual_table`.

It will dump virtual tables to `schema.rb` and ignore shadow tables. For example:
```sql
CREATE VIRTUAL TABLE searchables USING fts5(content, meta UNINDEXED, tokenize = 'porter ascii');
```
will append to `schema.rb`:
```ruby
create_virtual_table :searchables, :fts5, ["content", "meta UNINDEXED", "tokenize='porter ascii'"]
```

Notable changes:

* In order to filter out `virtual`/`shadow` tables from the regular table dump, I had to use `pragma_table_list` instead of `sqlite_master` in `ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements` because the schema table `sqlite_master` lacks virtual/shadow type information.
* I have added 2 new methods to the abstract adapter, but they are only used by the sqlite3 adapter. This is based on the postgresql enum implementation.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
